### PR TITLE
Phase 2: Core Agent Loop

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -1,0 +1,82 @@
+"""
+agent_loop.py
+Core Plan → Execute → Observe → Respond orchestration loop.
+Dispatches tasks to specialist agents and manages context state.
+"""
+
+import asyncio
+import logging
+from typing import Any
+from agents.rfp_parser_agent import RFPParserAgent
+# Future imports: SupplierAgent, ScoringAgent, etc.
+
+logger = logging.getLogger(__name__)
+
+AGENT_REGISTRY = {
+    "rfp_parser": RFPParserAgent,
+    # "supplier_matcher": SupplierMatcherAgent,
+    # "scoring":          ScoringAgent,
+    # "award":            AwardAgent,
+}
+
+class AgentLoop:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.context: dict[str, Any] = {}
+        self.history: list[dict] = []
+
+    async def run(self, task: str, payload: dict = {}) -> dict:
+        """
+        Main loop:  Plan → Execute → Observe → Respond
+        """
+        logger.info(f"[{self.session_id}] Task received: {task}")
+
+        # ── 1. PLAN ──────────────────────────────────────────
+        plan = self._plan(task, payload)
+        logger.info(f"[{self.session_id}] Plan: {plan}")
+
+        # ── 2. EXECUTE ───────────────────────────────────────
+        results = {}
+        for step in plan:
+            agent_key = step["agent"]
+            agent_cls = AGENT_REGISTRY.get(agent_key)
+            if not agent_cls:
+                logger.warning(f"Unknown agent: {agent_key}")
+                continue
+            agent = agent_cls(context=self.context)
+            results[agent_key] = await agent.run(step["input"])
+
+        # ── 3. OBSERVE ───────────────────────────────────────
+        self.context.update(results)
+        self.history.append({"task": task, "results": results})
+
+        # ── 4. RESPOND ───────────────────────────────────────
+        response = self._synthesise(results)
+        logger.info(f"[{self.session_id}] Response ready.")
+        return response
+
+    # ── Private helpers ──────────────────────────────────────
+
+    def _plan(self, task: str, payload: dict) -> list[dict]:
+        """
+        Naive task→agent routing.
+        Replace with LLM-based planner when ready.
+        """
+        task_lower = task.lower()
+        steps = []
+
+        if "parse" in task_lower or "rfp" in task_lower:
+            steps.append({"agent": "rfp_parser", "input": payload})
+
+        if not steps:
+            # Default: pass to rfp_parser as a catch-all during phase 2
+            steps.append({"agent": "rfp_parser", "input": payload})
+
+        return steps
+
+    def _synthesise(self, results: dict) -> dict:
+        return {
+            "session_id": self.session_id,
+            "status": "ok",
+            "output": results,
+        }

--- a/agents/rfp_parser_agent.py
+++ b/agents/rfp_parser_agent.py
@@ -1,0 +1,81 @@
+"""
+rfp_parser_agent.py
+Parses raw RFP documents (PDF/DOCX text) and extracts structured fields:
+  - title, buyer, deadline, categories, evaluation_criteria, attachments
+Uses NVIDIA NIM (Nemotron-253B) for reasoning-heavy extraction.
+"""
+
+import os
+import json
+import logging
+from typing import Any
+from openai import AsyncOpenAI   # NIM is OpenAI-compatible
+
+logger = logging.getLogger(__name__)
+
+NIM_BASE_URL    = os.getenv("NIM_BASE_URL",    "https://integrate.api.nvidia.com/v1")
+NIM_API_KEY     = os.getenv("NIM_API_KEY",     "")
+REASONING_MODEL = os.getenv("REASONING_MODEL", "nvidia/llama-3.1-nemotron-ultra-253b-v1")
+
+SYSTEM_PROMPT = """
+You are an RFP analysis expert. Given raw RFP text, extract and return a
+JSON object with these fields (use null if not found):
+{
+  "title":               string,
+  "buyer":               string,
+  "deadline":            string (ISO-8601 date or null),
+  "budget":              string (value + currency, or null),
+  "categories":          [string],
+  "evaluation_criteria": [{"criterion": string, "weight": number|null}],
+  "submission_format":   string,
+  "contact_email":       string|null,
+  "attachments_required":[string]
+}
+Return ONLY valid JSON — no markdown, no commentary.
+""".strip()
+
+
+class RFPParserAgent:
+    def __init__(self, context: dict[str, Any] = {}):
+        self.context = context
+        self.client  = AsyncOpenAI(
+            base_url=NIM_BASE_URL,
+            api_key=NIM_API_KEY,
+        )
+
+    async def run(self, payload: dict) -> dict:
+        """
+        payload expects:
+          {
+            "text":     str,   # raw extracted text from the RFP document
+            "filename": str    # original file name (for logging)
+          }
+        """
+        raw_text = payload.get("text", "")
+        filename = payload.get("filename", "unknown")
+
+        if not raw_text:
+            logger.warning(f"RFPParserAgent: empty text for {filename}")
+            return {"error": "No text provided", "filename": filename}
+
+        logger.info(f"RFPParserAgent: parsing {filename} ({len(raw_text)} chars)")
+
+        try:
+            response = await self.client.chat.completions.create(
+                model=REASONING_MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user",   "content": raw_text[:12_000]},  # token guard
+                ],
+                temperature=0.1,
+                max_tokens=1024,
+            )
+            raw_json = response.choices[0].message.content.strip()
+            parsed   = json.loads(raw_json)
+            parsed["filename"] = filename
+            logger.info(f"RFPParserAgent: successfully parsed {filename}")
+            return parsed
+
+        except Exception as exc:
+            logger.error(f"RFPParserAgent error for {filename}: {exc}")
+            return {"error": str(exc), "filename": filename}

--- a/rfp-intelligence-copilot/agent_loop/__init__.py
+++ b/rfp-intelligence-copilot/agent_loop/__init__.py
@@ -1,0 +1,2 @@
+# Phase 2 — Core Agent Loop
+# Plan → Execute → Observe → Respond

--- a/rfp-intelligence-copilot/api/deps.py
+++ b/rfp-intelligence-copilot/api/deps.py
@@ -1,0 +1,15 @@
+"""
+deps.py
+FastAPI dependency providers.
+
+Each request to POST /api/v1/rfp/parse gets a fresh AgentLoop
+with a unique session_id so context is fully isolated per call.
+"""
+
+import uuid
+from agent_loop import AgentLoop
+
+
+def get_agent_loop() -> AgentLoop:
+    """Dependency: returns a new AgentLoop per request."""
+    return AgentLoop(session_id=str(uuid.uuid4()))

--- a/rfp-intelligence-copilot/api/routes/rfp.py
+++ b/rfp-intelligence-copilot/api/routes/rfp.py
@@ -1,0 +1,114 @@
+"""
+rfp.py
+FastAPI router — POST /api/v1/rfp/parse
+
+Accepts a PDF or DOCX upload, extracts raw text, passes it through
+AgentLoop → RFPParserAgent, and returns structured JSON.
+"""
+
+import uuid
+import logging
+from io import BytesIO
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+
+from agent_loop import AgentLoop
+from api.deps import get_agent_loop
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/rfp", tags=["RFP"])
+
+# ── Accepted MIME types ───────────────────────────────────────────────────────
+ALLOWED_MIME = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+MAX_FILE_BYTES = 20 * 1024 * 1024  # 20 MB
+
+
+# ── Text extraction helpers ───────────────────────────────────────────────────
+
+def _extract_pdf(data: bytes) -> str:
+    """Extract plain text from a PDF using pypdf."""
+    try:
+        from pypdf import PdfReader
+        reader = PdfReader(BytesIO(data))
+        return "\n".join(
+            page.extract_text() or "" for page in reader.pages
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"PDF extraction failed: {exc}")
+
+
+def _extract_docx(data: bytes) -> str:
+    """Extract plain text from a DOCX using python-docx."""
+    try:
+        import docx
+        doc = docx.Document(BytesIO(data))
+        return "\n".join(para.text for para in doc.paragraphs)
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"DOCX extraction failed: {exc}")
+
+
+def _extract_text(filename: str, data: bytes, mime: str) -> str:
+    if mime == "application/pdf" or filename.lower().endswith(".pdf"):
+        return _extract_pdf(data)
+    return _extract_docx(data)
+
+
+# ── Route ─────────────────────────────────────────────────────────────────────
+
+@router.post("/parse", summary="Parse an RFP document")
+async def parse_rfp(
+    file: UploadFile = File(..., description="PDF or DOCX RFP document"),
+    loop: AgentLoop = Depends(get_agent_loop),
+):
+    """
+    Upload a PDF or DOCX RFP.  Returns a structured JSON object with:
+      title, buyer, deadline, budget, categories,
+      evaluation_criteria, submission_format, contact_email,
+      attachments_required.
+    """
+    # ── Validate MIME / size ──────────────────────────────────────────────────
+    content_type = file.content_type or ""
+    if content_type not in ALLOWED_MIME and not file.filename.lower().endswith(
+        (".pdf", ".docx")
+    ):
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported file type '{content_type}'. Upload a PDF or DOCX.",
+        )
+
+    raw_bytes = await file.read()
+    if len(raw_bytes) > MAX_FILE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File exceeds 20 MB limit ({len(raw_bytes) // 1024} KB received).",
+        )
+
+    logger.info(f"parse_rfp: received '{file.filename}' ({len(raw_bytes)} bytes)")
+
+    # ── Extract text ──────────────────────────────────────────────────────────
+    text = _extract_text(file.filename, raw_bytes, content_type)
+    if not text.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Could not extract any text from the uploaded file.",
+        )
+
+    # ── Run agent loop ────────────────────────────────────────────────────────
+    result = await loop.run(
+        task="parse rfp",
+        payload={"text": text, "filename": file.filename},
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "session_id": loop.session_id,
+            "filename":   file.filename,
+            "parsed":     result.get("output", {}).get("rfp_parser", {}),
+        },
+    )

--- a/rfp-intelligence-copilot/main.py
+++ b/rfp-intelligence-copilot/main.py
@@ -1,0 +1,62 @@
+"""
+main.py
+FastAPI application entrypoint.
+
+Start with:
+  uvicorn rfp-intelligence-copilot.main:app --reload --port 8000
+Or via Docker:
+  docker compose up
+"""
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from api.routes.rfp import router as rfp_router
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ── Lifespan (startup / shutdown hooks) ───────────────────────────────────────
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("RFP Intelligence Copilot API starting up...")
+    yield
+    logger.info("RFP Intelligence Copilot API shutting down.")
+
+
+# ── App ───────────────────────────────────────────────────────────────────────
+app = FastAPI(
+    title="RFP Intelligence Copilot",
+    description="AI-powered RFP parsing, scoring, and supplier matching.",
+    version="0.2.0",
+    lifespan=lifespan,
+)
+
+# Allow the React frontend (dev: localhost:5173, prod: Vercel domain)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:5173",
+        "https://*.vercel.app",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ── Routers ───────────────────────────────────────────────────────────────────
+app.include_router(rfp_router)
+
+
+# ── Health check ─────────────────────────────────────────────────────────────
+@app.get("/health", tags=["Meta"])
+def health():
+    return {"status": "ok", "version": app.version}


### PR DESCRIPTION
## Phase 2 — Core Agent Loop

This PR tracks all work for Phase 2 of the RFP Intelligence Copilot. It will be merged into `main` once all items below are complete.

---

### Scope

#### 🤖 Agent Orchestration
- [ ] Implement Plan → Execute → Observe → Respond loop in `agent_loop.py`
- [ ] Wire up all 10 specialist agents (RFP Parser, Supplier Matcher, Bid Evaluator, etc.)
- [ ] Add `pypdf2` PDF parsing to `rfp_parser_agent.py`
- [ ] Structured tool-call contracts between agent nodes

#### 📧 Supplier Invite Emails
- [ ] Complete SMTP integration in `email_service.py`
- [ ] Invite email template (HTML) with supplier portal deep-link
- [ ] Retry logic + delivery status tracking

#### 🗄️ Storage & Data
- [ ] GCS read/write for RFP documents and parsed outputs
- [ ] Supabase schema migrations for Phase 2 tables

#### 🧪 Tests
- [ ] Unit tests for agent loop state machine
- [ ] Integration test: PDF upload → parsed output in GCS
- [ ] Email send mock test

---

### Stack Decisions Locked
| Concern | Choice |
|---|---|
| Frontend framework | **Vite** (confirmed via Vercel project config) |
| PDF parsing | **pypdf2** |
| Email | **SMTP** via `smtplib` — vars already in `.env.example` |
| Storage | **GCS** (`STORAGE_BACKEND=gcs`) |

---

> 🔒 Do not merge until all checklist items are ticked and CI passes.